### PR TITLE
Test enhancement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,5 +32,10 @@
         "psr-4": {
             "Ancarda\\Type\\": "src"
         }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Test\\": "tests/"
+        }
     }
 }

--- a/tests/Math/UInt8Test.php
+++ b/tests/Math/UInt8Test.php
@@ -23,12 +23,14 @@ final class UInt8Test extends TestCase
     public function testRejectHighValues()
     {
         $this->expectException(DomainException::class);
+        $this->expectExceptionMessage('UInt8 cannot exceed 255 (0xFF)');
         new UInt8(random_int(256, 65535));
     }
 
     public function testRejectLowValues()
     {
         $this->expectException(DomainException::class);
+        $this->expectExceptionMessage('UInt8 cannot be lower than 0 (0x00)');
         new UInt8(random_int(-65535, -1));
     }
 }

--- a/tests/US/StateTest.php
+++ b/tests/US/StateTest.php
@@ -13,29 +13,34 @@ final class StateTest extends TestCase
     public function testFromCode()
     {
         $tx = new State('tx');
-        $this->assertEquals($tx->code(), 'TX');
-        $this->assertEquals($tx->name(), 'Texas');
-        $this->assertEquals((string) $tx, 'Texas (TX)');
-        $this->assertEquals(json_encode($tx), '{"code":"TX","name":"Texas"}');
+        $this->assertEquals('TX', $tx->code());
+        $this->assertEquals('Texas', $tx->name());
+        $this->assertEquals('Texas (TX)', (string) $tx);
+        $this->assertEquals('{"code":"TX","name":"Texas"}', json_encode($tx));
     }
 
-    public function testFromName()
+    public function fromNameProvider()
     {
-        $ak = new State('ARKANSAS');
-        $this->assertEquals($ak->code(), 'AR');
+        return [
+            ['ARKANSAS', 'AR'],
+            ['aLAbaMa', 'AL'],
+            [" \tGA\n", 'GA'],
+        ];
+    }
 
-        // Test that it works with lowercase and inconsistent case
-        $al = new State('aLAbaMa');
-        $this->assertEquals($al->code(), 'AL');
-
-        // Test trim
-        $ga = new State(" \tGA\n");
-        $this->assertEquals($ga->code(), 'GA');
+    /**
+     * @dataProvider fromNameProvider
+     */
+    public function testFromName($codeName, $expected)
+    {
+        $ak = new State($codeName);
+        $this->assertEquals($expected, $ak->code());
     }
 
     public function testRejectInvalidStates()
     {
         $this->expectException(DomainException::class);
+        $this->expectExceptionMessage('XX');
         new State('XX');
     }
 }


### PR DESCRIPTION
# Changed log
- Fix the assertions usage. The related assertion functions should be
`$this->assertEquals($expected, $actual)`.
- Using the `dataProvider` to collect the test cases and split the test cases from `test` methods.
- Using the correct assertions to asset the values.
For example, using the `assertTrue` and `assertFalse` to assert the bool value, not using `assertEquals`.